### PR TITLE
[HOTFIX] Fix asset pipeline for deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,9 +44,6 @@ gem 'rails-i18n'
 gem 'ostruct'
 gem 'mutex_m'
 
-gem 'sassc-rails'
-gem 'jquery-rails'
-
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem "pg", "~> 1.1"
 gem 'puma', '~> 3.11'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
+gem 'sassc-rails'
+
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,10 +133,6 @@ GEM
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    jquery-rails (4.6.0)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -252,14 +248,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     securerandom (0.3.1)
     selenium-webdriver (4.26.0)
       base64 (~> 0.2)
@@ -330,7 +318,6 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   jbuilder (~> 2.5)
-  jquery-rails
   listen (~> 3.5)
   mutex_m
   ostruct
@@ -340,7 +327,6 @@ DEPENDENCIES
   rails (~> 7.2)
   rails-i18n
   sass-rails (~> 5.0)
-  sassc-rails
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,6 +248,14 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     securerandom (0.3.1)
     selenium-webdriver (4.26.0)
       base64 (~> 0.2)
@@ -327,6 +335,7 @@ DEPENDENCIES
   rails (~> 7.2)
   rails-i18n
   sass-rails (~> 5.0)
+  sassc-rails
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 bundle install
-yarn install
+npm install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
 bundle exec rails db:migrate

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,11 +3,7 @@
 set -o errexit
 
 bundle install
+yarn install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
-
-# If you're using a Free instance type, you need to
-# perform database migrations in the build command.
-# Uncomment the following line:
-
-# bundle exec rails db:migrate
+bundle exec rails db:migrate

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,40 @@
 {
   "name": "crypto_wallet",
+  "lockfileVersion": 3,
   "requires": true,
-  "lockfileVersion": 1,
-  "dependencies": {
-    "bootstrap": {
+  "packages": {
+    "": {
+      "name": "crypto_wallet",
+      "dependencies": {
+        "bootstrap": "^5.3.3",
+        "jquery": "^3.7.1",
+        "notify-js-legacy": "^0.4.1"
+      }
+    },
+    "node_modules/bootstrap": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
-      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg=="
+      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
+      }
     },
-    "jquery": {
+    "node_modules/jquery": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
       "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
     },
-    "notify-js-legacy": {
+    "node_modules/notify-js-legacy": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/notify-js-legacy/-/notify-js-legacy-0.4.1.tgz",
       "integrity": "sha512-v9tUdioFeizt2Y+wD9Vg4MWN8zbX5BTLfjHMO9UBKKLODZSsfnlV+MWONWVldB6sXqvg3AbaYB407WxnmYZk/g=="


### PR DESCRIPTION
## [HOTFIX] Fix asset pipeline for deployment

### What?
Noways the asset-pipeline is not working properly when we have tried to deploy yesterday (12 Nov 2024), investigating further about the problem we have noticed is caused by two main reasons:

1. Render deployment file missing the `npm install` command
 This point is related to the oficial render guide that we have followed which indicates to use the build script without the `npm install` command that is responsible for downloading [our project JavaScript dependencies](https://github.com/GustavoTunes/crypto-wallet/blob/de80b9bb2f822ea954e6467457dac88a3b80e89c/package.json#L5-L7) so this was causing the erros related to JavaScript asset compilation. 

2. We have updated the rails version that uses sass but we have not set the sassc-rails
 We were getting another error related to the scss background syntaxe error but the actual issue was that this file was not able to be compiled by Sprockets because we were not using a gem to handle that this sassc-rails gem enables the project to compile such scss files.


Those two errors were not happening on the local env because at some point we have performed the command npm or yarn install solving the need to JavaScript compilation. About the scss error we got that and added that gem yesterday. 

### Why?
By solving those problems we are able to perform a deployment on production.

### How?
In summary the problems were solved by updating the deployment config files, we reach the solution by asking a lot of questions on Chat GPT about the asset-compile pipeline ([here is the prompt log in case of curiosity](https://chatgpt.com/share/673411c6-7a24-8002-8f96-f620004adb91)) also we performed a lot of tests running locally using the env as production.